### PR TITLE
Enable setting to change video progress counter to run down instead of up

### DIFF
--- a/src/Core/DatabaseManager.cpp
+++ b/src/Core/DatabaseManager.cpp
@@ -77,6 +77,7 @@ void DatabaseManager::initialize()
     sql.exec("INSERT INTO Configuration (Name, Value) VALUES('StartFullscreen', 'false')");
     sql.exec("INSERT INTO Configuration (Name, Value) VALUES('AutoRefreshLibrary', 'false')");
     sql.exec("INSERT INTO Configuration (Name, Value) VALUES('ShowThumbnailTooltip', 'true')");
+    sql.exec("INSERT INTO Configuration (Name, Value) VALUES('CountTimeDown', 'true')");
     sql.exec("INSERT INTO Configuration (Name, Value) VALUES('RefreshLibraryInterval', '60')");
     sql.exec("INSERT INTO Configuration (Name, Value) VALUES('GpiSerialPort', 'COM1')");
     sql.exec("INSERT INTO Configuration (Name, Value) VALUES('GpiBaudRate', '115200')");

--- a/src/Widgets/OscTimeWidget.cpp
+++ b/src/Widgets/OscTimeWidget.cpp
@@ -2,6 +2,8 @@
 
 #include "Global.h"
 
+#include "DatabaseManager.h"
+
 #include <QtCore/QDateTime>
 #include <QtCore/QTimer>
 #include <QtCore/QDebug>
@@ -29,14 +31,21 @@ void OscTimeWidget::reset()
     this->setVisible(false);
 }
 
-void OscTimeWidget::setTime(int currentFrame)
+void OscTimeWidget::setTime(int currentFrame, int length)
 {
     if (this->fps == 0)
         return;
 
     this->setVisible(true);
 
-    double currentTime = currentFrame * (1.0 / this->fps);
+    bool countTimeDown = (DatabaseManager::getInstance().getConfigurationByName("CountTimeDown").getValue() == "true") ? true : false;
+
+    double currentTime;
+    if(countTimeDown) {
+      currentTime = (length - currentFrame) * (1.0 / this->fps);
+    } else {
+      currentTime = currentFrame * (1.0 / this->fps);
+    }
 
     this->labelOscTime->setText(convertToTimecode(currentTime));
 

--- a/src/Widgets/OscTimeWidget.h
+++ b/src/Widgets/OscTimeWidget.h
@@ -13,7 +13,7 @@ class WIDGETS_EXPORT OscTimeWidget : public QWidget, Ui::OscTimeWidget
         explicit OscTimeWidget(QWidget* parent = 0);
 
         void reset();
-        void setTime(int currentFrame);
+        void setTime(int currentFrame, int length);
         void setInOutTime(int seek, int length);
         void setProgress(int currentFrame);
         void setFramesPerSecond(int fps);

--- a/src/Widgets/Rundown/RundownVideoWidget.cpp
+++ b/src/Widgets/Rundown/RundownVideoWidget.cpp
@@ -638,7 +638,7 @@ void RundownVideoWidget::pathSubscriptionReceived(const QString& predicate, cons
 
     this->fileModel->setPath(arguments.at(0).toString());
 
-    this->widgetOscTime->setTime(this->fileModel->getFrame());
+    this->widgetOscTime->setTime(this->fileModel->getFrame(), this->fileModel->getTotalFrames());
     this->widgetOscTime->setProgress(this->fileModel->getFrame());
 
     if (this->command.getSeek() == 0 && this->command.getLength() == 0)

--- a/src/Widgets/SettingsDialog.cpp
+++ b/src/Widgets/SettingsDialog.cpp
@@ -36,6 +36,10 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 
     this->checkBoxShowThumbnailTooltip->setChecked(showThumbnailTooltip);
 
+    bool countTimeDown = (DatabaseManager::getInstance().getConfigurationByName("CountTimeDown").getValue() == "true") ? true : false;
+
+    this->checkBoxCountTimeDown->setChecked(countTimeDown);
+
     loadDevices();
     loadGpi();
 }
@@ -211,6 +215,12 @@ void SettingsDialog::showThumbnailTooltipChanged(int state)
 {
     QString showThumbnailTooltip = (state == Qt::Checked) ? "true" : "false";
     DatabaseManager::getInstance().updateConfiguration(ConfigurationModel(0, "ShowThumbnailTooltip", showThumbnailTooltip));
+}
+
+void SettingsDialog::countTimeDownChanged(int state)
+{
+    QString countTimeDown = (state == Qt::Checked) ? "true" : "false";
+    DatabaseManager::getInstance().updateConfiguration(ConfigurationModel(0, "CountTimeDown", countTimeDown));
 }
 
 void SettingsDialog::synchronizeIntervalChanged(int interval)

--- a/src/Widgets/SettingsDialog.h
+++ b/src/Widgets/SettingsDialog.h
@@ -32,6 +32,7 @@ class WIDGETS_EXPORT SettingsDialog : public QDialog, Ui::SettingsDialog
         Q_SLOT void autoSynchronizeChanged(int);
         Q_SLOT void synchronizeIntervalChanged(int);
         Q_SLOT void showThumbnailTooltipChanged(int);
+        Q_SLOT void countTimeDownChanged(int);
         Q_SLOT void deviceItemDoubleClicked(QTreeWidgetItem*, int);
         Q_SLOT void gpi1Changed();
         Q_SLOT void gpi2Changed();

--- a/src/Widgets/SettingsDialog.ui
+++ b/src/Widgets/SettingsDialog.ui
@@ -295,6 +295,22 @@
       <string>Show thumbnail tooltip</string>
      </property>
     </widget>
+    <widget class="QCheckBox" name="checkBoxCountTimeDown">
+     <property name="geometry">
+      <rect>
+       <x>110</x>
+       <y>320</y>
+       <width>171</width>
+       <height>17</height>
+      </rect>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="text">
+      <string>Count video progress down</string>
+     </property>
+    </widget>
    </widget>
    <widget class="QWidget" name="tabDevices">
     <attribute name="title">
@@ -2268,8 +2284,8 @@
    <slot>showAddDeviceDialog()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>44</x>
-     <y>700</y>
+     <x>46</x>
+     <y>699</y>
     </hint>
     <hint type="destinationlabel">
      <x>39</x>
@@ -2284,8 +2300,8 @@
    <slot>removeDevice()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>86</x>
-     <y>700</y>
+     <x>88</x>
+     <y>699</y>
     </hint>
     <hint type="destinationlabel">
      <x>80</x>
@@ -2300,8 +2316,8 @@
    <slot>fontSizeChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>178</x>
-     <y>165</y>
+     <x>180</x>
+     <y>164</y>
     </hint>
     <hint type="destinationlabel">
      <x>437</x>
@@ -2332,8 +2348,8 @@
    <slot>synchronizeIntervalChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>195</x>
-     <y>316</y>
+     <x>197</x>
+     <y>273</y>
     </hint>
     <hint type="destinationlabel">
      <x>6</x>
@@ -2364,8 +2380,8 @@
    <slot>autoSynchronizeChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>127</x>
-     <y>275</y>
+     <x>129</x>
+     <y>232</y>
     </hint>
     <hint type="destinationlabel">
      <x>0</x>
@@ -2460,8 +2476,8 @@
    <slot>gpi6Changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>244</x>
-     <y>345</y>
+     <x>246</x>
+     <y>344</y>
     </hint>
     <hint type="destinationlabel">
      <x>699</x>
@@ -2492,8 +2508,8 @@
    <slot>gpi8Changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>247</x>
-     <y>401</y>
+     <x>249</x>
+     <y>400</y>
     </hint>
     <hint type="destinationlabel">
      <x>699</x>
@@ -2604,8 +2620,8 @@
    <slot>gpi6Changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>301</x>
-     <y>345</y>
+     <x>303</x>
+     <y>344</y>
     </hint>
     <hint type="destinationlabel">
      <x>551</x>
@@ -2620,8 +2636,8 @@
    <slot>gpi7Changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>301</x>
-     <y>373</y>
+     <x>303</x>
+     <y>372</y>
     </hint>
     <hint type="destinationlabel">
      <x>262</x>
@@ -2636,8 +2652,8 @@
    <slot>gpi8Changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>353</x>
-     <y>401</y>
+     <x>355</x>
+     <y>400</y>
     </hint>
     <hint type="destinationlabel">
      <x>705</x>
@@ -2748,8 +2764,8 @@
    <slot>gpo4Changed()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>217</x>
-     <y>569</y>
+     <x>219</x>
+     <y>568</y>
     </hint>
     <hint type="destinationlabel">
      <x>-61</x>
@@ -2924,8 +2940,8 @@
    <slot>showThumbnailTooltipChanged(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>266</x>
-     <y>388</y>
+     <x>268</x>
+     <y>341</y>
     </hint>
     <hint type="destinationlabel">
      <x>701</x>
@@ -2946,6 +2962,22 @@
     <hint type="destinationlabel">
      <x>703</x>
      <y>476</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBoxCountTimeDown</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>SettingsDialog</receiver>
+   <slot>countTimeDownChanged(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>362</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>832</x>
+     <y>402</y>
     </hint>
    </hints>
   </connection>
@@ -2978,5 +3010,6 @@
   <slot>baudRateChanged(QString)</slot>
   <slot>autoStepChanged(int)</slot>
   <slot>showThumbnailTooltipChanged(int)</slot>
+  <slot>countTimeDownChanged(int)</slot>
  </slots>
 </ui>


### PR DESCRIPTION
This enables a setting in the General tab called "Count video progress
down" which when enabled (by default) counts the video progress down to
zero instead of up to the files duration.  This is the most common
practise in productions.
