### PR TITLE
Verify stored data are added to template

### DIFF
--- a/src/Widgets/Inspector/InspectorTemplateWidget.cpp
+++ b/src/Widgets/Inspector/InspectorTemplateWidget.cpp
@@ -87,6 +87,9 @@ void InspectorTemplateWidget::showAddTemplateDataDialog(const ShowAddTemplateDat
 
 void InspectorTemplateWidget::addTemplateData(const AddTemplateDataEvent& event)
 {
+    if (this->isHidden())
+        return;
+
     this->treeWidgetTemplateData->clear();
     this->fieldCounter = 0;
 


### PR DESCRIPTION
If we try to add stored data when rundown is empty then we get sigsegv. I have got sigsegvs randomly also when there were selected elements other then template. So I think we should add stored data only if template is selected - I have done that by checking result of isHidden method on InspectorTemplateWidget.