### PR TITLE
Properly handle drop-frame frame rates (eg, 29.97, 59.94)

### DIFF
--- a/src/Caspar/CasparDevice.cpp
+++ b/src/Caspar/CasparDevice.cpp
@@ -653,11 +653,12 @@ void CasparDevice::sendNotification()
                     // "CG1080I50"  MOVIE  6159792 20121101150514 264 1/25
                     // "GO1080P25"  MOVIE  16694084 20121101150514 445 1/25
                     // "WIPE"  MOVIE  1268784 20121101150514 31 1/25
+                    // "HOOLOOVOO"  MOVIE  1111111 22222222222222 333 100/2997
                     QString totalFrames = response.split("\" ").at(1).trimmed().split(" ").at(4);
-                    QString timebase = response.split("\" ").at(1).trimmed().split(" ").at(5);
+                    QStringList timebase = response.split("\" ").at(1).trimmed().split(" ").at(5).split("/");
 
                     int frames = totalFrames.toInt();
-                    int fps = timebase.split("/").at(1).toInt();
+                    double fps = timebase.at(1).toDouble() / timebase.at(0).toDouble();
 
                     double time = frames * (1.0 / fps);
                     timecode = Timecode::fromTime(time, fps);
@@ -693,7 +694,7 @@ void CasparDevice::sendNotification()
             emit templateChanged(items, *this);
 
             break;
-        }       
+        }
         case AmcpDevice::AmcpDeviceCommand::INFO:
         {
             AmcpDevice::response.removeFirst(); // First post is the header, 200 INFO OK.

--- a/src/Common/Global.h
+++ b/src/Common/Global.h
@@ -108,7 +108,7 @@ namespace Osc
     static const int DEFAULT_PAUSE_Y = 14;
     static const int COMPACT_PAUSE_X = 102;
     static const int COMPACT_PAUSE_Y = 0;
-    static const QString DEFAULT_TIME = "00:00:00:00";
+    static const QString DEFAULT_TIME = "00:00:00.00";
     static const QString DEFAULT_TIME_FILTER = "#IPADDRESS#/channel/#CHANNEL#/stage/layer/#VIDEOLAYER#/file/time";
     static const QString DEFAULT_FRAME_FILTER = "#IPADDRESS#/channel/#CHANNEL#/stage/layer/#VIDEOLAYER#/file/frame";
     static const QString DEFAULT_FPS_FILTER = "#IPADDRESS#/channel/#CHANNEL#/stage/layer/#VIDEOLAYER#/file/fps";

--- a/src/Common/Timecode.cpp
+++ b/src/Common/Timecode.cpp
@@ -13,7 +13,7 @@ QString Timecode::fromTime(const QTime& time)
     return result.append(QString("%1").arg(msec));
 }
 
-QString Timecode::fromTime(double time, int fps)
+QString Timecode::fromTime(double time, double fps)
 {
     int hour;
     int minutes;

--- a/src/Common/Timecode.cpp
+++ b/src/Common/Timecode.cpp
@@ -4,7 +4,7 @@
 
 QString Timecode::fromTime(const QTime& time)
 {
-    QString result = time.toString("hh:mm:ss").append(":");
+    QString result = time.toString("hh:mm:ss").append(".");
 
     int msec = time.msec() / 10;
     if (msec < 10)
@@ -27,5 +27,5 @@ QString Timecode::fromTime(double time, double fps)
     seconds = (int)(time - hour * 3600 - minutes * 60);
     frames = (int)((time - hour * 3600 - minutes * 60 - seconds) * fps);
 
-    return smpteFormat.sprintf("%02d:%02d:%02d:%02d", hour, minutes, seconds, frames);
+    return smpteFormat.sprintf("%02d:%02d:%02d.%02d", hour, minutes, seconds, frames);
 }

--- a/src/Common/Timecode.h
+++ b/src/Common/Timecode.h
@@ -9,7 +9,7 @@ class COMMON_EXPORT Timecode
 {
     public:
         static QString fromTime(const QTime& time);
-        static QString fromTime(double time, int fps);
+        static QString fromTime(double time, double fps);
 
     private:
         Timecode() {}

--- a/src/Core/Models/OscFileModel.cpp
+++ b/src/Core/Models/OscFileModel.cpp
@@ -45,12 +45,12 @@ void OscFileModel::setTotalFrames(int totalFrames)
     this->totalFrames = totalFrames;
 }
 
-int OscFileModel::getFramesPerSecond() const
+double OscFileModel::getFramesPerSecond() const
 {
     return this->fps;
 }
 
-void OscFileModel::setFramesPerSecond(int fps)
+void OscFileModel::setFramesPerSecond(double fps)
 {
     this->fps = fps;
 }

--- a/src/Core/Models/OscFileModel.h
+++ b/src/Core/Models/OscFileModel.h
@@ -21,8 +21,8 @@ class CORE_EXPORT OscFileModel
         int getTotalFrames() const;
         void setTotalFrames(int totalFrames);
 
-        int getFramesPerSecond() const;
-        void setFramesPerSecond(int fps);
+        double getFramesPerSecond() const;
+        void setFramesPerSecond(double fps);
 
         const QString& getPath() const;
         void setPath(const QString& path);
@@ -32,7 +32,7 @@ class CORE_EXPORT OscFileModel
         double totalTime;
         int currentFrame;
         int totalFrames;
-        int fps;
+        double fps;
         QString path;
 };
 

--- a/src/Widgets/OscTimeWidget.cpp
+++ b/src/Widgets/OscTimeWidget.cpp
@@ -116,7 +116,7 @@ void OscTimeWidget::setProgress(int currentFrame)
     this->progressBarOscTime->update();
 }
 
-void OscTimeWidget::setFramesPerSecond(int fps)
+void OscTimeWidget::setFramesPerSecond(double fps)
 {
     this->fps = fps;
 }

--- a/src/Widgets/OscTimeWidget.h
+++ b/src/Widgets/OscTimeWidget.h
@@ -17,14 +17,14 @@ class WIDGETS_EXPORT OscTimeWidget : public QWidget, Ui::OscTimeWidget
         void setStartTime(const QString& startTime, bool reverseOscTime);
         void setInOutTime(int seek, int length);
         void setProgress(int currentFrame);
-        void setFramesPerSecond(int fps);
+        void setFramesPerSecond(double fps);
         void setPaused(bool paused);
         void setLoop(bool loop);
 
         void setCompactView(bool compactView);
 
     private:
-        int fps;
+        double fps;
         bool paused;
         qint64 timestamp;
         QString startTime;

--- a/src/Widgets/OscTimeWidget.ui
+++ b/src/Widgets/OscTimeWidget.ui
@@ -51,7 +51,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>00:00:00:00</string>
+    <string>00:00:00.00</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignCenter</set>
@@ -67,7 +67,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>00:00:00:00</string>
+    <string>00:00:00.00</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -83,7 +83,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>00:00:00:00</string>
+    <string>00:00:00.00</string>
    </property>
    <property name="alignment">
     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Widgets/Rundown/RundownMovieWidget.cpp
+++ b/src/Widgets/Rundown/RundownMovieWidget.cpp
@@ -1085,7 +1085,7 @@ void RundownMovieWidget::fpsSubscriptionReceived(const QString& predicate, const
     if (this->fileModel == NULL)
         return;
 
-    this->fileModel->setFramesPerSecond(arguments.at(0).toInt());
+    this->fileModel->setFramesPerSecond(arguments.at(0).toDouble());
 }
 
 void RundownMovieWidget::pathSubscriptionReceived(const QString& predicate, const QList<QVariant>& arguments)


### PR DESCRIPTION
For some stupid reason we still use frame rates with drop-frame in the US. Server reports these as 100/2997 or even 1000000/29970029, which screws up Client's fps math.