### PR TITLE
Strip leading directories

### DIFF
--- a/src/Widgets/Inspector/InspectorMetadataWidget.cpp
+++ b/src/Widgets/Inspector/InspectorMetadataWidget.cpp
@@ -30,7 +30,7 @@ void InspectorMetadataWidget::rundownItemSelected(const RundownItemSelectedEvent
 
     this->lineEditLabel->setEnabled(true);
     this->lineEditLabel->setReadOnly(false);
-    this->lineEditLabel->setText(this->model->getLabel());
+    this->lineEditLabel->setText(this->model->getLabel().split('/').last());
 
     blockAllSignals(false);
 }

--- a/src/Widgets/Rundown/RundownAudioWidget.cpp
+++ b/src/Widgets/Rundown/RundownAudioWidget.cpp
@@ -44,7 +44,7 @@ RundownAudioWidget::RundownAudioWidget(const LibraryModel& model, QWidget* paren
     this->labelGroupColor->setStyleSheet(QString("background-color: %1;").arg(Color::DEFAULT_GROUP_COLOR));
     this->labelColor->setStyleSheet(QString("background-color: %1;").arg(Color::DEFAULT_AUDIO_COLOR));
 
-    this->labelLabel->setText(this->model.getLabel());
+    this->labelLabel->setText(this->model.getLabel().split('/').last());
     this->labelChannel->setText(QString("Channel: %1").arg(this->command.getChannel()));
     this->labelVideolayer->setText(QString("Video layer: %1").arg(this->command.getVideolayer()));
     this->labelDelay->setText(QString("Delay: %1").arg(this->command.getDelay()));
@@ -83,7 +83,7 @@ void RundownAudioWidget::labelChanged(const LabelChangedEvent& event)
 
     this->model.setLabel(event.getLabel());
 
-    this->labelLabel->setText(this->model.getLabel());
+    this->labelLabel->setText(this->model.getLabel().split('/').last());
 }
 
 void RundownAudioWidget::targetChanged(const TargetChangedEvent& event)

--- a/src/Widgets/Rundown/RundownMovieWidget.cpp
+++ b/src/Widgets/Rundown/RundownMovieWidget.cpp
@@ -50,7 +50,7 @@ RundownMovieWidget::RundownMovieWidget(const LibraryModel& model, QWidget* paren
     this->labelGroupColor->setStyleSheet(QString("background-color: %1;").arg(Color::DEFAULT_GROUP_COLOR));
     this->labelColor->setStyleSheet(QString("background-color: %1;").arg(Color::DEFAULT_MOVIE_COLOR));
 
-    this->labelLabel->setText(this->model.getLabel());
+    this->labelLabel->setText(this->model.getLabel().split('/').last());
     this->labelChannel->setText(QString("Channel: %1").arg(this->command.getChannel()));
     this->labelVideolayer->setText(QString("Video layer: %1").arg(this->command.getVideolayer()));
     this->labelDelay->setText(QString("Delay: %1").arg(this->command.getDelay()));
@@ -119,7 +119,7 @@ void RundownMovieWidget::labelChanged(const LabelChangedEvent& event)
 
     this->model.setLabel(event.getLabel());
 
-    this->labelLabel->setText(this->model.getLabel());
+    this->labelLabel->setText(this->model.getLabel().split('/').last());
 }
 
 void RundownMovieWidget::targetChanged(const TargetChangedEvent& event)

--- a/src/Widgets/Rundown/RundownStillWidget.cpp
+++ b/src/Widgets/Rundown/RundownStillWidget.cpp
@@ -42,7 +42,7 @@ RundownStillWidget::RundownStillWidget(const LibraryModel& model, QWidget* paren
     this->labelGroupColor->setStyleSheet(QString("background-color: %1;").arg(Color::DEFAULT_GROUP_COLOR));
     this->labelColor->setStyleSheet(QString("background-color: %1;").arg(Color::DEFAULT_STILL_COLOR));
 
-    this->labelLabel->setText(this->model.getLabel());
+    this->labelLabel->setText(this->model.getLabel().split('/').last());
     this->labelChannel->setText(QString("Channel: %1").arg(this->command.getChannel()));
     this->labelVideolayer->setText(QString("Video layer: %1").arg(this->command.getVideolayer()));
     this->labelDelay->setText(QString("Delay: %1").arg(this->command.getDelay()));
@@ -79,7 +79,7 @@ void RundownStillWidget::labelChanged(const LabelChangedEvent& event)
         return;
 
     this->model.setLabel(event.getLabel());
-    this->labelLabel->setText(this->model.getLabel());
+    this->labelLabel->setText(this->model.getLabel().split('/').last());
 }
 
 void RundownStillWidget::targetChanged(const TargetChangedEvent& event)


### PR DESCRIPTION
To improve readability, strip leading directories from the file name in the movie, audio, still and metadata inspector widgets.

I use the Client on a regular basis for live show production. We have a large file structure with folders within folders for different shows. I find it much easier to find things in the playlist, when only the file names are shown. Otherwise, the names become very long and since the letters are all capital, things gets pretty gnarly.

Of course, this is just my opinion and if you think otherwise, feel free to reject this request. No hurt feelings.