### PR TITLE
Trigger control events immediately + Increased duration value

### DIFF
--- a/src/Osc/OscListener.cpp
+++ b/src/Osc/OscListener.cpp
@@ -85,9 +85,8 @@ void OscListener::ProcessMessage(const osc::ReceivedMessage& message, const IpEn
     {
         qDebug("Received OSC message over UDP from %s:%d: %s", qPrintable(addressBuffer), this->port, qPrintable(eventMessage));
 
-        // Do not overwrite control commands already in queue.
-        if (!this->events.contains(eventPath))
-            this->events[eventPath] = arguments;
+        // Trigger control events immediately.
+        emit messageReceived(eventPath, arguments);
     }
     else
         this->events[eventPath] = arguments;

--- a/src/Widgets/Inspector/InspectorOutputWidget.ui
+++ b/src/Widgets/Inspector/InspectorOutputWidget.ui
@@ -144,7 +144,7 @@
         </sizepolicy>
        </property>
        <property name="maximum">
-        <number>99999</number>
+        <number>999999999</number>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Trigger control events immediately. This will cause two events to be triggered when using software such TouchOSC because OSC messages will be triggered both on press (1) and release (0). The last event will be suppressed further up in the UI. The good thing is that control events will be processed faster, see issue #195.

Increased duration value in the output panel, see issue #194.