### PR TITLE
AnchorCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/AnchorCommand.cpp
+++ b/src/Core/Commands/AnchorCommand.cpp
@@ -19,7 +19,7 @@ float AnchorCommand::getPositionY() const
 
 int AnchorCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& AnchorCommand::getTween() const
@@ -49,10 +49,10 @@ void AnchorCommand::setPositionY(float positionY)
     emit positionYChanged(this->positionY);
 }
 
-void AnchorCommand::setTransitionDuration(int transtitionDuration)
+void AnchorCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void AnchorCommand::setTween(const QString& tween)
@@ -79,7 +79,7 @@ void AnchorCommand::readProperties(boost::property_tree::wptree& pt)
 
     setPositionX(pt.get(L"positionx", Mixer::DEFAULT_FILL_XPOS));
     setPositionY(pt.get(L"positiony", Mixer::DEFAULT_FILL_YPOS));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setTriggerOnNext(pt.get(L"triggeronnext", Fill::DEFAULT_TRIGGER_ON_NEXT));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
@@ -91,7 +91,7 @@ void AnchorCommand::writeProperties(QXmlStreamWriter* writer)
 
     writer->writeTextElement("positionx", QString::number(getPositionX()));
     writer->writeTextElement("positiony", QString::number(getPositionY()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("triggeronnext", (getTriggerOnNext() == true) ? "true" : "false");
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");

--- a/src/Core/Commands/AnchorCommand.h
+++ b/src/Core/Commands/AnchorCommand.h
@@ -33,7 +33,7 @@ class CORE_EXPORT AnchorCommand : public AbstractCommand
 
         void setPositionX(float positionX);
         void setPositionY(float positionY);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setTriggerOnNext(bool triggerOnNext);
         void setDefer(bool defer);
@@ -47,11 +47,11 @@ class CORE_EXPORT AnchorCommand : public AbstractCommand
         bool defer = Mixer::DEFAULT_DEFER;
         bool triggerOnNext = Anchor::DEFAULT_TRIGGER_ON_NEXT;
 
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
 
         Q_SIGNAL void positionXChanged(float);
         Q_SIGNAL void positionYChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void triggerOnNextChanged(bool);
         Q_SIGNAL void deferChanged(bool);


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.