### PR TITLE
BrightnessCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/BrightnessCommand.cpp
+++ b/src/Core/Commands/BrightnessCommand.cpp
@@ -14,7 +14,7 @@ float BrightnessCommand::getBrightness() const
 
 int BrightnessCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& BrightnessCommand::getTween() const
@@ -33,10 +33,10 @@ void BrightnessCommand::setBrightness(float brightness)
     emit brightnessChanged(this->brightness);
 }
 
-void BrightnessCommand::setTransitionDuration(int transtitionDuration)
+void BrightnessCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void BrightnessCommand::setTween(const QString& tween)
@@ -56,7 +56,7 @@ void BrightnessCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setBrightness(pt.get(L"brightness", Mixer::DEFAULT_BRIGHTNESS));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -66,7 +66,7 @@ void BrightnessCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("brightness", QString::number(getBrightness()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", this->getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/BrightnessCommand.h
+++ b/src/Core/Commands/BrightnessCommand.h
@@ -30,18 +30,18 @@ class CORE_EXPORT BrightnessCommand : public AbstractCommand
         bool getDefer() const;
 
         void setBrightness(float brightness);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
     private:
         float brightness = Mixer::DEFAULT_BRIGHTNESS;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool defer = Mixer::DEFAULT_DEFER;
 
         Q_SIGNAL void brightnessChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.