### PR TITLE
ContrastCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/ContrastCommand.cpp
+++ b/src/Core/Commands/ContrastCommand.cpp
@@ -14,7 +14,7 @@ float ContrastCommand::getContrast() const
 
 int ContrastCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& ContrastCommand::getTween() const
@@ -33,10 +33,10 @@ void ContrastCommand::setContrast(float contrast)
     emit contrastChanged(this->contrast);
 }
 
-void ContrastCommand::setTransitionDuration(int transtitionDuration)
+void ContrastCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void ContrastCommand::setTween(const QString& tween)
@@ -56,7 +56,7 @@ void ContrastCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setContrast(pt.get(L"contrast", Mixer::DEFAULT_CONTRAST));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -66,7 +66,7 @@ void ContrastCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("contrast", QString::number(getContrast()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", this->getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/ContrastCommand.h
+++ b/src/Core/Commands/ContrastCommand.h
@@ -30,18 +30,18 @@ class CORE_EXPORT ContrastCommand : public AbstractCommand
         bool getDefer() const;
 
         void setContrast(float contrast);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
     private: 
         float contrast = Mixer::DEFAULT_CONTRAST;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool defer = Mixer::DEFAULT_DEFER;
 
         Q_SIGNAL void contrastChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.