### PR TITLE
CropCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/CropCommand.cpp
+++ b/src/Core/Commands/CropCommand.cpp
@@ -29,7 +29,7 @@ float CropCommand::getBottom() const
 
 int CropCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& CropCommand::getTween() const
@@ -66,10 +66,10 @@ void CropCommand::setBottom(float bottom)
     emit bottomChanged(this->bottom);
 }
 
-void CropCommand::setTransitionDuration(int transtitionDuration)
+void CropCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void CropCommand::setTween(const QString& tween)
@@ -92,7 +92,7 @@ void CropCommand::readProperties(boost::property_tree::wptree& pt)
     setTop(pt.get(L"top", Mixer::DEFAULT_CROP_TOP));
     setRight(pt.get(L"right", Mixer::DEFAULT_CROP_RIGHT));
     setBottom(pt.get(L"bottom", Mixer::DEFAULT_CROP_BOTTOM));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -105,7 +105,7 @@ void CropCommand::writeProperties(QXmlStreamWriter* writer)
     writer->writeTextElement("top", QString::number(getTop()));
     writer->writeTextElement("right", QString::number(getRight()));
     writer->writeTextElement("bottom", QString::number(getBottom()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", this->getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/CropCommand.h
+++ b/src/Core/Commands/CropCommand.h
@@ -36,7 +36,7 @@ class CORE_EXPORT CropCommand : public AbstractCommand
         void setTop(float top);
         void setRight(float right);
         void setBottom(float bottom);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
@@ -45,7 +45,7 @@ class CORE_EXPORT CropCommand : public AbstractCommand
         float top = Mixer::DEFAULT_CROP_TOP;
         float right = Mixer::DEFAULT_CROP_RIGHT;
         float bottom = Mixer::DEFAULT_CROP_BOTTOM;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool defer = Mixer::DEFAULT_DEFER;
 
@@ -53,7 +53,7 @@ class CORE_EXPORT CropCommand : public AbstractCommand
         Q_SIGNAL void topChanged(float);
         Q_SIGNAL void rightChanged(float);
         Q_SIGNAL void bottomChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.