### PR TITLE
DeckLinkInputCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/DeckLinkInputCommand.cpp
+++ b/src/Core/Commands/DeckLinkInputCommand.cpp
@@ -24,7 +24,7 @@ const QString& DeckLinkInputCommand::getTransition() const
 
 int DeckLinkInputCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& DeckLinkInputCommand::getDirection() const
@@ -55,10 +55,10 @@ void DeckLinkInputCommand::setTransition(const QString& transition)
     emit transitionChanged(this->transition);
 }
 
-void DeckLinkInputCommand::setTransitionDuration(int transtitionDuration)
+void DeckLinkInputCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void DeckLinkInputCommand::setDirection(const QString& direction)
@@ -80,7 +80,7 @@ void DeckLinkInputCommand::readProperties(boost::property_tree::wptree& pt)
     setDevice(pt.get(L"device", DeckLinkInput::DEFAULT_DEVICE));
     setFormat(QString::fromStdWString(pt.get(L"format", DeckLinkInput::DEFAULT_FORMAT.toStdWString())));
     setTransition(QString::fromStdWString(pt.get(L"transition", Mixer::DEFAULT_TRANSITION.toStdWString())));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDirection(QString::fromStdWString(pt.get(L"direction", Mixer::DEFAULT_DIRECTION.toStdWString())));
 }
@@ -92,7 +92,7 @@ void DeckLinkInputCommand::writeProperties(QXmlStreamWriter* writer)
     writer->writeTextElement("device", QString::number(getDevice()));
     writer->writeTextElement("format", getFormat());
     writer->writeTextElement("transition", getTransition());
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("direction", getDirection());
 }

--- a/src/Core/Commands/DeckLinkInputCommand.h
+++ b/src/Core/Commands/DeckLinkInputCommand.h
@@ -34,7 +34,7 @@ class CORE_EXPORT DeckLinkInputCommand : public AbstractCommand
         void setDevice(int device);
         void setFormat(const QString& format);
         void setTransition(const QString& transition);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDirection(const QString& direction);
 
@@ -42,14 +42,14 @@ class CORE_EXPORT DeckLinkInputCommand : public AbstractCommand
         int device = DeckLinkInput::DEFAULT_DEVICE;
         QString format = DeckLinkInput::DEFAULT_FORMAT;
         QString transition = Mixer::DEFAULT_TRANSITION;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         QString direction = Mixer::DEFAULT_DIRECTION;
 
         Q_SIGNAL void deviceChanged(int);
         Q_SIGNAL void formatChanged(QString);
         Q_SIGNAL void transitionChanged(const QString&);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void directionChanged(const QString&);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void resetDevice(QString);


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.