### PR TITLE
FadeToBlackCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/FadeToBlackCommand.cpp
+++ b/src/Core/Commands/FadeToBlackCommand.cpp
@@ -20,7 +20,7 @@ const QString& FadeToBlackCommand::getTransition() const
 
 int FadeToBlackCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& FadeToBlackCommand::getDirection() const
@@ -49,10 +49,10 @@ void FadeToBlackCommand::setTransition(const QString& transition)
     emit transitionChanged(this->transition);
 }
 
-void FadeToBlackCommand::setTransitionDuration(int transtitionDuration)
+void FadeToBlackCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void FadeToBlackCommand::setDirection(const QString& direction)
@@ -84,7 +84,7 @@ void FadeToBlackCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setTransition(QString::fromStdWString(pt.get(L"transition", Mixer::DEFAULT_TRANSITION.toStdWString())));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDirection(QString::fromStdWString(pt.get(L"direction", Mixer::DEFAULT_DIRECTION.toStdWString())));
     setUseAuto(pt.get(L"useauto", FadeToBlack::DEFAULT_USE_AUTO));
@@ -96,7 +96,7 @@ void FadeToBlackCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("transition", getTransition());
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("direction", getDirection());
     writer->writeTextElement("useauto", (getUseAuto() == true) ? "true" : "false");

--- a/src/Core/Commands/FadeToBlackCommand.h
+++ b/src/Core/Commands/FadeToBlackCommand.h
@@ -33,7 +33,7 @@ class CORE_EXPORT FadeToBlackCommand : public AbstractCommand
         bool getTriggerOnNext() const;
 
         void setTransition(const QString& transition);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDirection(const QString& direction);
         void setUseAuto(bool useAuto);
@@ -42,14 +42,14 @@ class CORE_EXPORT FadeToBlackCommand : public AbstractCommand
     private:
         QString color = FadeToBlack::DEFAULT_COLOR;
         QString transition = FadeToBlack::DEFAULT_TRANSITION;
-        int transtitionDuration = FadeToBlack::DEFAULT_DURATION;
+        int transitionDuration = FadeToBlack::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         QString direction = Mixer::DEFAULT_DIRECTION;
         bool useAuto = FadeToBlack::DEFAULT_USE_AUTO;
         bool triggerOnNext = FadeToBlack::DEFAULT_TRIGGER_ON_NEXT;
 
         Q_SIGNAL void transitionChanged(const QString&);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void directionChanged(const QString&);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void useAutoChanged(bool);


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.