### PR TITLE
FillCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/FillCommand.cpp
+++ b/src/Core/Commands/FillCommand.cpp
@@ -29,7 +29,7 @@ float FillCommand::getScaleY() const
 
 int FillCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& FillCommand::getTween() const
@@ -76,10 +76,10 @@ void FillCommand::setScaleY(float scaleY)
     emit scaleYChanged(this->scaleY);
 }
 
-void FillCommand::setTransitionDuration(int transtitionDuration)
+void FillCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void FillCommand::setTween(const QString& tween)
@@ -114,7 +114,7 @@ void FillCommand::readProperties(boost::property_tree::wptree& pt)
     setPositionY(pt.get(L"positiony", Mixer::DEFAULT_FILL_YPOS));
     setScaleX(pt.get(L"scalex", Mixer::DEFAULT_FILL_XSCALE));
     setScaleY(pt.get(L"scaley", Mixer::DEFAULT_FILL_YSCALE));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setTriggerOnNext(pt.get(L"triggeronnext", Fill::DEFAULT_TRIGGER_ON_NEXT));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
@@ -129,7 +129,7 @@ void FillCommand::writeProperties(QXmlStreamWriter* writer)
     writer->writeTextElement("positiony", QString::number(getPositionY()));
     writer->writeTextElement("scalex", QString::number(getScaleX()));
     writer->writeTextElement("scaley", QString::number(getScaleY()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("triggeronnext", (getTriggerOnNext() == true) ? "true" : "false");
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");

--- a/src/Core/Commands/FillCommand.h
+++ b/src/Core/Commands/FillCommand.h
@@ -38,7 +38,7 @@ class CORE_EXPORT FillCommand : public AbstractCommand
         void setPositionY(float positionY);
         void setScaleX(float scaleX);
         void setScaleY(float scaleY);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setTriggerOnNext(bool triggerOnNext);
         void setDefer(bool defer);
@@ -49,7 +49,7 @@ class CORE_EXPORT FillCommand : public AbstractCommand
         float positionY = Mixer::DEFAULT_FILL_YPOS;
         float scaleX = Mixer::DEFAULT_FILL_XSCALE;
         float scaleY = Mixer::DEFAULT_FILL_YSCALE;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool triggerOnNext = Fill::DEFAULT_TRIGGER_ON_NEXT;
         bool defer = Mixer::DEFAULT_DEFER;
@@ -59,7 +59,7 @@ class CORE_EXPORT FillCommand : public AbstractCommand
         Q_SIGNAL void positionYChanged(float);
         Q_SIGNAL void scaleXChanged(float);
         Q_SIGNAL void scaleYChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void triggerOnNextChanged(bool);
         Q_SIGNAL void deferChanged(bool);


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.