### PR TITLE
LevelsCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/LevelsCommand.cpp
+++ b/src/Core/Commands/LevelsCommand.cpp
@@ -34,7 +34,7 @@ float LevelsCommand::getGamma() const
 
 int LevelsCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& LevelsCommand::getTween() const
@@ -77,10 +77,10 @@ void LevelsCommand::setGamma(float gamma)
     emit gammaChanged(this->gamma);
 }
 
-void LevelsCommand::setTransitionDuration(int transtitionDuration)
+void LevelsCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void LevelsCommand::setTween(const QString& tween)
@@ -104,7 +104,7 @@ void LevelsCommand::readProperties(boost::property_tree::wptree& pt)
     setMinOut(pt.get(L"minout", Mixer::DEFAULT_LEVELS_MIN_OUT));
     setMaxOut(pt.get(L"maxout", Mixer::DEFAULT_LEVELS_MAX_OUT));
     setGamma(pt.get(L"gamma", Mixer::DEFAULT_LEVELS_GAMMA));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -118,7 +118,7 @@ void LevelsCommand::writeProperties(QXmlStreamWriter* writer)
     writer->writeTextElement("minout", QString::number(getMinOut()));
     writer->writeTextElement("maxout", QString::number(getMaxOut()));
     writer->writeTextElement("gamma", QString::number(getGamma()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/LevelsCommand.h
+++ b/src/Core/Commands/LevelsCommand.h
@@ -38,7 +38,7 @@ class CORE_EXPORT LevelsCommand : public AbstractCommand
         void setMinOut(float minOut);
         void setMaxOut(float maxOut);
         void setGamma(float gamma);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
@@ -48,7 +48,7 @@ class CORE_EXPORT LevelsCommand : public AbstractCommand
         float minOut = Mixer::DEFAULT_LEVELS_MIN_OUT;
         float maxOut = Mixer::DEFAULT_LEVELS_MAX_OUT;
         float gamma = Mixer::DEFAULT_LEVELS_GAMMA;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool defer = Mixer::DEFAULT_DEFER;
 
@@ -57,7 +57,7 @@ class CORE_EXPORT LevelsCommand : public AbstractCommand
         Q_SIGNAL void minOutChanged(float);
         Q_SIGNAL void maxOutChanged(float);
         Q_SIGNAL void gammaChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.