### PR TITLE
OpacityCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/OpacityCommand.cpp
+++ b/src/Core/Commands/OpacityCommand.cpp
@@ -14,7 +14,7 @@ float OpacityCommand::getOpacity() const
 
 int OpacityCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& OpacityCommand::getTween() const
@@ -38,10 +38,10 @@ void OpacityCommand::setOpacity(float opacity)
     emit opacityChanged(this->opacity);
 }
 
-void OpacityCommand::setTransitionDuration(int transtitionDuration)
+void OpacityCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void OpacityCommand::setTween(const QString& tween)
@@ -67,7 +67,7 @@ void OpacityCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setOpacity(pt.get(L"opacity", Mixer::DEFAULT_OPACITY));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setTriggerOnNext(pt.get(L"triggeronnext", Opacity::DEFAULT_TRIGGER_ON_NEXT));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
@@ -78,7 +78,7 @@ void OpacityCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("opacity", QString::number(getOpacity()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("triggeronnext", (getTriggerOnNext() == true) ? "true" : "false");
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");

--- a/src/Core/Commands/OpacityCommand.h
+++ b/src/Core/Commands/OpacityCommand.h
@@ -31,20 +31,20 @@ class CORE_EXPORT OpacityCommand : public AbstractCommand
         bool getDefer() const;
 
         void setOpacity(float opacity);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setTriggerOnNext(bool triggerOnNext);
         void setDefer(bool defer);
 
     private:
         float opacity = Mixer::DEFAULT_OPACITY;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool triggerOnNext = Opacity::DEFAULT_TRIGGER_ON_NEXT;
         bool defer = Mixer::DEFAULT_DEFER;
 
         Q_SIGNAL void opacityChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void triggerOnNextChanged(bool);
         Q_SIGNAL void deferChanged(bool);


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.