### PR TITLE
RotationCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/RotationCommand.cpp
+++ b/src/Core/Commands/RotationCommand.cpp
@@ -14,7 +14,7 @@ float RotationCommand::getRotation() const
 
 int RotationCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 bool RotationCommand::getTriggerOnNext() const
@@ -38,10 +38,10 @@ void RotationCommand::setRotation(float rotation)
     emit rotationChanged(this->rotation);
 }
 
-void RotationCommand::setTransitionDuration(int transtitionDuration)
+void RotationCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void RotationCommand::setTween(const QString& tween)
@@ -67,7 +67,7 @@ void RotationCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setRotation(pt.get(L"rotation", Mixer::DEFAULT_ROTATION));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -77,7 +77,7 @@ void RotationCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("rotation", QString::number(getRotation()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", this->getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/RotationCommand.h
+++ b/src/Core/Commands/RotationCommand.h
@@ -31,21 +31,21 @@ class CORE_EXPORT RotationCommand : public AbstractCommand
         bool getDefer() const;
 
         void setRotation(float rotation);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTriggerOnNext(bool triggerOnNext);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
     private:
         float rotation = Mixer::DEFAULT_ROTATION;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool triggerOnNext = Rotation::DEFAULT_TRIGGER_ON_NEXT;
         bool defer = Mixer::DEFAULT_DEFER;
 
         Q_SIGNAL void triggerOnNextChanged(bool);
         Q_SIGNAL void rotationChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.