### PR TITLE
SaturationCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/SaturationCommand.cpp
+++ b/src/Core/Commands/SaturationCommand.cpp
@@ -14,7 +14,7 @@ float SaturationCommand::getSaturation() const
 
 int SaturationCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& SaturationCommand::getTween() const
@@ -33,10 +33,10 @@ void SaturationCommand::setSaturation(float saturation)
     emit saturationChanged(this->saturation);
 }
 
-void SaturationCommand::setTransitionDuration(int transtitionDuration)
+void SaturationCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void SaturationCommand::setTween(const QString& tween)
@@ -56,7 +56,7 @@ void SaturationCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setSaturation(pt.get(L"saturation", Mixer::DEFAULT_SATURATION));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -66,7 +66,7 @@ void SaturationCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("saturation", QString::number(getSaturation()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/SaturationCommand.h
+++ b/src/Core/Commands/SaturationCommand.h
@@ -30,18 +30,18 @@ class CORE_EXPORT SaturationCommand : public AbstractCommand
         bool getDefer() const;
 
         void setSaturation(float saturation);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
     private:
         float saturation = Mixer::DEFAULT_SATURATION;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool defer = Mixer::DEFAULT_DEFER;
 
         Q_SIGNAL void saturationChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.