### PR TITLE
SolidColorCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/SolidColorCommand.cpp
+++ b/src/Core/Commands/SolidColorCommand.cpp
@@ -39,7 +39,7 @@ const QString& SolidColorCommand::getTransition() const
 
 int SolidColorCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& SolidColorCommand::getDirection() const
@@ -74,10 +74,10 @@ void SolidColorCommand::setTransition(const QString& transition)
     emit transitionChanged(this->transition);
 }
 
-void SolidColorCommand::setTransitionDuration(int transtitionDuration)
+void SolidColorCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void SolidColorCommand::setDirection(const QString& direction)
@@ -109,7 +109,7 @@ void SolidColorCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setTransition(QString::fromStdWString(pt.get(L"transition", Mixer::DEFAULT_TRANSITION.toStdWString())));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDirection(QString::fromStdWString(pt.get(L"direction", Mixer::DEFAULT_DIRECTION.toStdWString())));
     setColor(QString::fromStdWString(pt.get(L"solidcolor", SolidColor::DEFAULT_COLOR.toStdWString())));
@@ -122,7 +122,7 @@ void SolidColorCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("transition", getTransition());
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("direction", getDirection());
     writer->writeTextElement("solidcolor", getColor());

--- a/src/Core/Commands/SolidColorCommand.h
+++ b/src/Core/Commands/SolidColorCommand.h
@@ -35,7 +35,7 @@ class CORE_EXPORT SolidColorCommand : public AbstractCommand
 
         void setColor(const QString& color);
         void setTransition(const QString& transition);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDirection(const QString& direction);
         void setUseAuto(bool useAuto);
@@ -44,7 +44,7 @@ class CORE_EXPORT SolidColorCommand : public AbstractCommand
     private:
         QString color = SolidColor::DEFAULT_COLOR;
         QString transition = Mixer::DEFAULT_TRANSITION;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         QString direction = Mixer::DEFAULT_DIRECTION;
         bool useAuto = SolidColor::DEFAULT_USE_AUTO;
@@ -52,7 +52,7 @@ class CORE_EXPORT SolidColorCommand : public AbstractCommand
 
         Q_SIGNAL void colorChanged(const QString&);
         Q_SIGNAL void transitionChanged(const QString&);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void directionChanged(const QString&);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void useAutoChanged(bool);


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.