### PR TITLE
VolumeCommand: fix typo in transitionDuration (extra "t")

### DIFF
--- a/src/Core/Commands/VolumeCommand.cpp
+++ b/src/Core/Commands/VolumeCommand.cpp
@@ -15,7 +15,7 @@ float VolumeCommand::getVolume() const
 
 int VolumeCommand::getTransitionDuration() const
 {
-    return this->transtitionDuration;
+    return this->transitionDuration;
 }
 
 const QString& VolumeCommand::getTween() const
@@ -34,10 +34,10 @@ void VolumeCommand::setVolume(float volume)
     emit volumeChanged(this->volume);
 }
 
-void VolumeCommand::setTransitionDuration(int transtitionDuration)
+void VolumeCommand::setTransitionDuration(int transitionDuration)
 {
-    this->transtitionDuration = transtitionDuration;
-    emit transtitionDurationChanged(this->transtitionDuration);
+    this->transitionDuration = transitionDuration;
+    emit transitionDurationChanged(this->transitionDuration);
 }
 
 void VolumeCommand::setTween(const QString& tween)
@@ -57,7 +57,7 @@ void VolumeCommand::readProperties(boost::property_tree::wptree& pt)
     AbstractCommand::readProperties(pt);
 
     setVolume(pt.get(L"volume", Mixer::DEFAULT_VOLUME));
-    setTransitionDuration(pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION));
+    setTransitionDuration(pt.get(L"transitionDuration", pt.get(L"transtitionDuration", Mixer::DEFAULT_DURATION)));
     setTween(QString::fromStdWString(pt.get(L"tween", Mixer::DEFAULT_TWEEN.toStdWString())));
     setDefer(pt.get(L"defer", Mixer::DEFAULT_DEFER));
 }
@@ -67,7 +67,7 @@ void VolumeCommand::writeProperties(QXmlStreamWriter* writer)
     AbstractCommand::writeProperties(writer);
 
     writer->writeTextElement("volume", QString::number(getVolume()));
-    writer->writeTextElement("transtitionDuration", QString::number(getTransitionDuration()));
+    writer->writeTextElement("transitionDuration", QString::number(getTransitionDuration()));
     writer->writeTextElement("tween", getTween());
     writer->writeTextElement("defer", (getDefer() == true) ? "true" : "false");
 }

--- a/src/Core/Commands/VolumeCommand.h
+++ b/src/Core/Commands/VolumeCommand.h
@@ -30,18 +30,18 @@ class CORE_EXPORT VolumeCommand : public AbstractCommand
         bool getDefer() const;
 
         void setVolume(float volume);
-        void setTransitionDuration(int transtitionDuration);
+        void setTransitionDuration(int transitionDuration);
         void setTween(const QString& tween);
         void setDefer(bool defer);
 
     private:
         float volume = Mixer::DEFAULT_VOLUME;
-        int transtitionDuration = Mixer::DEFAULT_DURATION;
+        int transitionDuration = Mixer::DEFAULT_DURATION;
         QString tween = Mixer::DEFAULT_TWEEN;
         bool defer = Mixer::DEFAULT_DEFER;
 
         Q_SIGNAL void volumeChanged(float);
-        Q_SIGNAL void transtitionDurationChanged(int);
+        Q_SIGNAL void transitionDurationChanged(int);
         Q_SIGNAL void tweenChanged(const QString&);
         Q_SIGNAL void deferChanged(bool);
 };


### PR DESCRIPTION
For now, support reading "transtitionChanged" from the XML file, to
avoid breaking existing rundowns.
Users should be advised to open and save their rundowns to fix the typo.