### PR TITLE
Some minor fixes for the Atem audio input inspectors

### DIFF
--- a/src/Widgets/Inspector/Atem/InspectorAtemAudioInputBalanceWidget.cpp
+++ b/src/Widgets/Inspector/Atem/InspectorAtemAudioInputBalanceWidget.cpp
@@ -76,7 +76,6 @@ void InspectorAtemAudioInputBalanceWidget::loadAtemAudioInput()
     this->comboBoxInput->blockSignals(true);
 
     this->comboBoxInput->clear();
-    this->comboBoxInput->addItem("Master", "0");
 
     foreach (quint16 key, this->inputs.keys())
     {

--- a/src/Widgets/Inspector/Atem/InspectorAtemAudioInputStateWidget.cpp
+++ b/src/Widgets/Inspector/Atem/InspectorAtemAudioInputStateWidget.cpp
@@ -98,6 +98,9 @@ void InspectorAtemAudioInputStateWidget::blockAllSignals(bool block)
 
 void InspectorAtemAudioInputStateWidget::loadAtemInputState()
 {
+    if (comboBoxState->count())
+        return;
+
     // We do not have a command object, block the signals.
     // Events will not be triggered while we update the values.
     this->comboBoxState->blockSignals(true);

--- a/src/Widgets/Inspector/Atem/InspectorAtemAudioInputStateWidget.cpp
+++ b/src/Widgets/Inspector/Atem/InspectorAtemAudioInputStateWidget.cpp
@@ -79,7 +79,6 @@ void InspectorAtemAudioInputStateWidget::loadAtemAudioInput()
     this->comboBoxInput->blockSignals(true);
 
     this->comboBoxInput->clear();
-    this->comboBoxInput->addItem("Master", "0");
     foreach (quint16 key, this->inputs.keys())
     {
         if (this->inputs.value(key).internalType == 0 || this->inputs.value(key).internalType == 4)


### PR DESCRIPTION
Avoid duplication of the input state and don't allow to set balance and state on the master channel.