### PR TITLE
[master] Fixed compile issue on Mac OSX Mojave.

### DIFF
--- a/src/Common/Global.h
+++ b/src/Common/Global.h
@@ -2,6 +2,7 @@
 
 #pragma GCC diagnostic ignored "-Wformat-security"
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 
 #include <QtCore/QByteArray>
 #include <QtCore/QDebug>


### PR DESCRIPTION
Fixed compile issue on Mac OSX due to missing override keyword.