### PR TITLE
Enable OSC control of preview

### DIFF
--- a/src/Widgets/Rundown/RundownTreeWidget.h
+++ b/src/Widgets/Rundown/RundownTreeWidget.h
@@ -110,6 +110,7 @@ class WIDGETS_EXPORT RundownTreeWidget : public QWidget, Ui::RundownTreeWidget
         OscSubscription* nextControlSubscription;
         OscSubscription* updateControlSubscription;
         OscSubscription* invokeControlSubscription;
+        OscSubscription* previewControlSubscription;
         OscSubscription* clearControlSubscription;
         OscSubscription* clearVideolayerControlSubscription;
         OscSubscription* clearChannelControlSubscription;
@@ -204,6 +205,7 @@ class WIDGETS_EXPORT RundownTreeWidget : public QWidget, Ui::RundownTreeWidget
         Q_SLOT void nextControlSubscriptionReceived(const QString&, const QList<QVariant>&);
         Q_SLOT void updateControlSubscriptionReceived(const QString&, const QList<QVariant>&);
         Q_SLOT void invokeControlSubscriptionReceived(const QString&, const QList<QVariant>&);
+        Q_SLOT void previewControlSubscriptionReceived(const QString&, const QList<QVariant>&)
         Q_SLOT void clearControlSubscriptionReceived(const QString&, const QList<QVariant>&);
         Q_SLOT void clearVideolayerControlSubscriptionReceived(const QString&, const QList<QVariant>&);
         Q_SLOT void clearChannelControlSubscriptionReceived(const QString&, const QList<QVariant>&);


### PR DESCRIPTION
This pull request enables OSC commands such as `control/preview` to display a media element on the server preview channel defined in the client configuration. It is configured to operate if the client configuration is NOT set to "Show preview on auto-step" mode.

The mode can be switched to always enabling OSC control by removing the final condition, `&& !this->previewOnAutoStep` , in new line number 1946 of RundownTreeWidget.cpp  