### PR TITLE
chore: Document Qt requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the deb file and launch 'CasparCG Client'. Tested on Ubuntu 22.04 64-bit
 ## Development
 
 #### Windows
-* Install Qt 6.5 for Windows from [Qt archive](https://www.qt.io/download). You may wish to select a more minimal installation than the full 6.5 tree.
+* Install Qt 6.5 for Windows from [Qt archive](https://www.qt.io/download). You may wish to select a more minimal installation than the full 6.5 tree. At a minimum the additional library *Qt WebSockets* and the *Qt 5 Comaptibility Module* are required.
 * Install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/)
 * Install [CMake](https://cmake.org/download/)
 


### PR DESCRIPTION
It was already stated that a more minimal installation could suffice but it wasn't stated what is actually required at a minimum. This commit records what additional components on top of the "MSVC 2019 64-bit" component were required to get a successful build.