### PR TITLE
Fix malformed color command #293

### DIFF
--- a/src/Core/Commands/SolidColorCommand.cpp
+++ b/src/Core/Commands/SolidColorCommand.cpp
@@ -28,10 +28,10 @@ const QString SolidColorCommand::getPremultipliedColor() const
     green = (green * alpha) / 255;
     blue = (blue * alpha) / 255;
 
-    return QString("#%1%2%3%4").arg(alpha, 2, 16)
-                               .arg(red, 2, 16)
-                               .arg(green, 2, 16)
-                               .arg(blue, 2, 16);
+    return QString("#%1%2%3%4").arg(alpha, 2, 16, QChar('0'))
+                               .arg(red, 2, 16, QChar('0'))
+                               .arg(green, 2, 16, QChar('0'))
+                               .arg(blue, 2, 16, QChar('0'));
 }
 
 const QString& SolidColorCommand::getTransition() const

--- a/src/Widgets/Inspector/InspectorSolidColorWidget.cpp
+++ b/src/Widgets/Inspector/InspectorSolidColorWidget.cpp
@@ -123,10 +123,10 @@ void InspectorSolidColorWidget::colorDialogClicked()
 
     if (dialog.exec() == QDialog::Accepted)
     {
-        QString color = QString("#%1%2%3%4").arg(dialog.selectedColor().alpha(), 2, 16)
-                                            .arg(dialog.selectedColor().red(), 2, 16)
-                                            .arg(dialog.selectedColor().green(), 2, 16)
-                                            .arg(dialog.selectedColor().blue(), 2, 16);
+        QString color = QString("#%1%2%3%4").arg(dialog.selectedColor().alpha(), 2, 16, QChar('0'))
+                                            .arg(dialog.selectedColor().red(), 2, 16, QChar('0'))
+                                            .arg(dialog.selectedColor().green(), 2, 16, QChar('0'))
+                                            .arg(dialog.selectedColor().blue(), 2, 16, QChar('0'));
 
         this->lineEditColor->setText(color.toUpper());
     }


### PR DESCRIPTION
In dd9895c118fa25c8a72a28ed8b5e7254f35d8a76 the `printf` syntax using `%02d` was replaced with `QString` and its `arg` function. The default fill character of `arg` is a whitespace. This broke the formatting of the color code if they had a leading zero in any component.

In 22c838ba5fd26c1b796c8915797fc633a21415d3 this was fixed for `Timecode.cpp`. The same fix was now also applied in the other places.