### PR TITLE
Some corrections(Json and correct order of function calls) and some improvements(saveAs,Open).

### DIFF
--- a/src/Core/Commands/TemplateCommand.cpp
+++ b/src/Core/Commands/TemplateCommand.cpp
@@ -54,14 +54,15 @@ const QString TemplateCommand::getTemplateData() const
     {
         if (this->sendAsJson)
         {
-            templateData.append("{");
+            QJsonObject jsonObject;
             foreach (KeyValueModel model, this->models)
             {
-                templateData.append(QString("\\\"%1\\\":\\\"%2\\\",").arg(model.getKey())
-                                                                     .arg((this->useUppercaseData == true) ? model.getValue().toUpper() : model.getValue()));
+                jsonObject[model.getKey()] = (this->useUppercaseData == true) ? model.getValue().toUpper() : model.getValue();
             }
-            templateData.chop(1);
-            templateData.append("}");
+            QJsonDocument jsonDocument(jsonObject);
+            QString strJson(jsonDocument.toJson(QJsonDocument::Compact));
+            strJson.replace("\"", "\\\"");
+            templateData.append(strJson);
         }
         else
         {

--- a/src/Core/Commands/TemplateCommand.h
+++ b/src/Core/Commands/TemplateCommand.h
@@ -10,6 +10,8 @@
 #include <boost/property_tree/xml_parser.hpp>
 
 #include <QtCore/QString>
+#include <QJsonObject>
+#include <QJsonDocument>
 
 class QObject;
 class QXmlStreamWriter;

--- a/src/Widgets/Library/DeviceFilterWidget.cpp
+++ b/src/Widgets/Library/DeviceFilterWidget.cpp
@@ -25,8 +25,9 @@ DeviceFilterWidget::DeviceFilterWidget(QWidget* parent)
     this->listWidget.addItem(item);
     this->lineEditDeviceFilter->setText(item->text());
 
-    this->comboBoxDeviceFilter->setView(&this->listWidget);
     this->comboBoxDeviceFilter->setModel(this->listWidget.model());
+    this->comboBoxDeviceFilter->setView(&this->listWidget);
+
 
     QObject::connect(&this->listWidget, SIGNAL(itemPressed(QListWidgetItem*)), this, SLOT(itemPressed(QListWidgetItem*)));
     QObject::connect(&DeviceManager::getInstance(), SIGNAL(deviceRemoved()), this, SLOT(deviceRemoved()));

--- a/src/Widgets/Rundown/RundownTreeWidget.cpp
+++ b/src/Widgets/Rundown/RundownTreeWidget.cpp
@@ -707,17 +707,24 @@ void RundownTreeWidget::saveRundown(bool saveAs)
         return;
 
     QString path;
-    if (saveAs)
-        path = QFileDialog::getSaveFileName(this, "Save Rundown", QDir::homePath(), "Rundown (*.xml)");
+    if (saveAs) {
+        if (this->activeRundown == Rundown::DEFAULT_NAME) {
+            path = QDir::homePath();
+        }
+        else {
+            QFileInfo fi(this->activeRundown);
+            path = fi.absolutePath();
+        }
+        path = QFileDialog::getSaveFileName(this, "Save Rundown", path, "Rundown (*.xml)");
+    }
     else
         path = (this->activeRundown == Rundown::DEFAULT_NAME) ? QFileDialog::getSaveFileName(this, "Save Rundown", QDir::homePath(), "Rundown (*.xml)") : this->activeRundown;
 
-    // Make sure we have an extension. On *nix system it will not be appended by default.
-    if (!path.toLower().endsWith(".xml"))
-        path.append(".xml");
-
     if (!path.isEmpty())
     {
+        // Make sure we have an extension. On *nix system it will not be appended by default.
+        if (!path.toLower().endsWith(".xml"))
+            path.append(".xml");
         EventManager::getInstance().fireStatusbarEvent(StatusbarEvent("Saving rundown..."));
 
         QFile file(path);

--- a/src/Widgets/Rundown/RundownWidget.cpp
+++ b/src/Widgets/Rundown/RundownWidget.cpp
@@ -279,9 +279,17 @@ void RundownWidget::openRundown(const OpenRundownEvent& event)
 {
     QString path = "";
 
-    if (event.getPath().isEmpty())
-        path = QFileDialog::getOpenFileName(this, "Open Rundown", QDir::homePath(), "Rundown (*.xml)");
-    else
+    if (event.getPath().isEmpty()){
+        QList<QString> paths = DatabaseManager::getInstance().getOpenRecent();
+        if(paths.count() > 0){
+                path = paths.at(0);
+                QFileInfo fi(path);
+                path = fi.absolutePath();
+        }else{
+                path = QDir::homePath();
+        }
+        path = QFileDialog::getOpenFileName(this, "Open Rundown", path , "Rundown (*.xml)");
+    }else
         path = event.getPath();
 
     if (!path.isEmpty())


### PR DESCRIPTION
File DeviceFilterWidget: Correction based on https://doc.qt.io/qt-6/qcombobox.html#setView
Note: If you want to use the convenience views (like QListWidget, QTableWidget or QTreeWidget), make sure to call setModel() on the combobox with the convenience widgets model before calling this function.
    
File RundowWidget.cpp: open on dir of the last opened file, to avoid going to the entire path again to open a file on the same directory.

File RundownTreeWidget.cpp: on save as, open folder of the active Rundown or HomeDir if active == DEFAULT_NAME

Files src/Core/Commands/TemplateCommand.cpp, src/Core/Commands/TemplateCommand.h: Uses QT Json library to convert to single line json. Avoids errors on new lines and other caracters that could break the update function call.
